### PR TITLE
feat: 제품 안정화 및 옵션 반영 신뢰성 개선

### DIFF
--- a/TextifyApp/TextifyApp.xcodeproj/project.pbxproj
+++ b/TextifyApp/TextifyApp.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		F3A8C9749B29830B43804F60 /* ControlBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8418CFDBD506DDF9C4172F05 /* ControlBottomSheet.swift */; };
 		F40627CFDE592EE3DA8B7412 /* TypingEffectText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C913FCC10DDE0AB8D638C22 /* TypingEffectText.swift */; };
 		F5FBF13B89AEF748AEC25144 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B134CD45B93EB6A3E62158C /* SettingsViewModelTests.swift */; };
+		F6A1B2C3D4E5067890ABCDEF /* PhotoLibraryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F607A8B9C0D1E2 /* PhotoLibraryServiceTests.swift */; };
 		FB4DBB2EB89DD207E7724F70 /* ImageExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00CDD46C7D1D1C241CB86E5 /* ImageExportService.swift */; };
 /* End PBXBuildFile section */
 
@@ -174,6 +175,7 @@
 		09E2EBCA4AE223C0FFD125A2 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		0AC08B5CB686E3ACBD9D8C99 /* ImageProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProcessor.swift; sourceTree = "<group>"; };
 		0E511AFAB36A6034E47CC0F7 /* PhotoLibrarySaveAuthorizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibrarySaveAuthorizationServiceTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F607A8B9C0D1E2 /* PhotoLibraryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryServiceTests.swift; sourceTree = "<group>"; };
 		0FD65EBEF36830EE68978596 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		186E7EBBE057CA88D8267C2C /* AppDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDependencies.swift; sourceTree = "<group>"; };
 		1AD1DA18B6504D4D4EB0002B /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 			children = (
 				7415076EA20200C09E33DB68 /* HistoryDetailViewModelTests.swift */,
 				0E511AFAB36A6034E47CC0F7 /* PhotoLibrarySaveAuthorizationServiceTests.swift */,
+				A1B2C3D4E5F607A8B9C0D1E2 /* PhotoLibraryServiceTests.swift */,
 				5B134CD45B93EB6A3E62158C /* SettingsViewModelTests.swift */,
 				C852E60D3D02B93D5C491735 /* TextArtHistoryRecorderTests.swift */,
 				1E020444B0D87351993A0B4F /* TextifyUITests.swift */,
@@ -825,6 +828,7 @@
 			files = (
 				8F63EDE337643ABA300D321C /* HistoryDetailViewModelTests.swift in Sources */,
 				9653505DE93CE063EFD014DC /* PhotoLibrarySaveAuthorizationServiceTests.swift in Sources */,
+				F6A1B2C3D4E5067890ABCDEF /* PhotoLibraryServiceTests.swift in Sources */,
 				F5FBF13B89AEF748AEC25144 /* SettingsViewModelTests.swift in Sources */,
 				18FBA6EFD22C579E0A9403F2 /* TextArtHistoryRecorderTests.swift in Sources */,
 				59BA2270492583A74BBFB3E3 /* TextifyUITests.swift in Sources */,

--- a/TextifyApp/TextifyApp.xcodeproj/project.pbxproj
+++ b/TextifyApp/TextifyApp.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 		23A653692EEE63985F6BB94C /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		2626B013FF9449C6B3EC7FA9 /* TextifyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextifyViewModel.swift; sourceTree = "<group>"; };
 		267E213001462A77C75DADF6 /* AnimatedGradient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedGradient.swift; sourceTree = "<group>"; };
-		2855231387C1F837FFC76C48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		2855231387C1F837FFC76C48 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		2B8A3F0F8A2FF448FE145F2E /* TextArt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextArt.swift; sourceTree = "<group>"; };
 		2C9653FDB8A4B5F834C3A1A0 /* LoadingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingButton.swift; sourceTree = "<group>"; };
 		2F013CD8D68F092F1A89C2D6 /* TextifyUI.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = TextifyUI.docc; sourceTree = "<group>"; };
@@ -194,12 +194,12 @@
 		3C3466B68372B0726AC55BF2 /* PhotoLibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryService.swift; sourceTree = "<group>"; };
 		45375506F126815B50817CDF /* HistoryEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryEntry.swift; sourceTree = "<group>"; };
 		476FC664EF185E25718CF186 /* HistoryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCard.swift; sourceTree = "<group>"; };
-		48525068E5BE1F36D2F8CDD8 /* TextifyUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TextifyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		48525068E5BE1F36D2F8CDD8 /* TextifyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TextifyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F8E43D4026B00DC2C4B7845 /* VisualPalettePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualPalettePicker.swift; sourceTree = "<group>"; };
 		517BE47F884F74094A5A64DF /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		531C2362A1851484ACB88E79 /* AppearanceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceService.swift; sourceTree = "<group>"; };
 		5559274068B2F0FD73FD6206 /* PhotoLibrarySaveAuthorizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibrarySaveAuthorizationService.swift; sourceTree = "<group>"; };
-		570501EC17F9701FA3F44EBA /* TextifyKitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TextifyKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		570501EC17F9701FA3F44EBA /* TextifyKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TextifyKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B03DB97AE00943CF3E5F1CA /* CharacterMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterMapperTests.swift; sourceTree = "<group>"; };
 		5B134CD45B93EB6A3E62158C /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		6137DCC41D0B9BD0512C58A0 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
@@ -239,7 +239,7 @@
 		EFE02C1FBE95E8ECE405A847 /* CharacterPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterPaletteTests.swift; sourceTree = "<group>"; };
 		F00CDD46C7D1D1C241CB86E5 /* ImageExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageExportService.swift; sourceTree = "<group>"; };
 		F17A0C97DB20ECBFD4E67768 /* FloatingToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingToolbar.swift; sourceTree = "<group>"; };
-		F55A54C000F76F3A9FD25ABD /* TextifyApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = TextifyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F55A54C000F76F3A9FD25ABD /* TextifyApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TextifyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F82E6F6E43E844BE537E9E2D /* TextifyKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextifyKitTests.swift; sourceTree = "<group>"; };
 		FBB2D0E392705A6C92FF31E5 /* TextifyKit.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = TextifyKit.docc; sourceTree = "<group>"; };
 		FDC92BF75C34F1A95C11FE7D /* RetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryView.swift; sourceTree = "<group>"; };
@@ -721,8 +721,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1500;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 0215FB9C97D973C051D143C2 /* Build configuration list for PBXProject "TextifyApp" */;
 			developmentRegion = en;
@@ -892,6 +890,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HY47J4787Q;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TextifyApp/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1031,6 +1030,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = HY47J4787Q;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1047,6 +1047,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = HY47J4787Q;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1155,6 +1156,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = HY47J4787Q;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1173,6 +1175,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HY47J4787Q;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TextifyApp/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1191,6 +1194,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = HY47J4787Q;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TextifyApp/TextifyUI/Features/History/HistoryDetailViewModel.swift
+++ b/TextifyApp/TextifyUI/Features/History/HistoryDetailViewModel.swift
@@ -58,13 +58,18 @@ public final class HistoryDetailViewModel {
     }
 
     public func prepareShareImage() async {
+        guard !isPreparingShare else { return }
+
         isPreparingShare = true
         errorMessage = nil
 
         do {
             shareURL = try await exportService.exportAsImage(textArt: textArt)
         } catch {
-            errorMessage = "이미지 공유 준비에 실패했습니다."
+            errorMessage = makeImageExportPresentation(
+                for: error,
+                context: .sharePreparation
+            ).message
         }
 
         isPreparingShare = false

--- a/TextifyApp/TextifyUI/Features/Textify/TextifyView.swift
+++ b/TextifyApp/TextifyUI/Features/Textify/TextifyView.swift
@@ -225,8 +225,10 @@ public struct TextifyView: View {
                     comparisonSourceLayer(height: height)
 
                     comparisonASCIILayer(height: height)
-                        .frame(width: max(revealX, 0), alignment: .leading)
-                        .clipped()
+                        .mask(alignment: .leading) {
+                            Rectangle()
+                                .frame(width: max(revealX, 0))
+                        }
 
                     comparisonSliderDivider(x: revealX, height: height)
                 }
@@ -297,13 +299,22 @@ public struct TextifyView: View {
                         .foregroundStyle(AppTheme.textArtForeground.opacity(0.85))
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let textArt = viewModel.textArt?.asString, !textArt.isEmpty {
-                Text(textArt)
-                    .font(.system(size: 4, design: .monospaced))
-                    .foregroundStyle(AppTheme.textArtForeground)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .padding(12)
-                    .clipped()
+            } else if let textArt = viewModel.textArt, !textArt.asString.isEmpty {
+                GeometryReader { proxy in
+                    let cols = max(CGFloat(textArt.width), 1)
+                    let rows = max(CGFloat(textArt.height), 1)
+                    // SF Mono metrics: advance width ≈ 0.6×size, line height ≈ 1.2×size
+                    let fitW = proxy.size.width / (cols * 0.6)
+                    let fitH = proxy.size.height / (rows * 1.2)
+                    let fontSize = max(min(fitW, fitH), 0.5)
+
+                    Text(textArt.asString)
+                        .font(.system(size: fontSize, design: .monospaced))
+                        .foregroundStyle(AppTheme.textArtForeground)
+                        .fixedSize()
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .clipped()
+                }
             } else {
                 VStack(spacing: 8) {
                     Image(systemName: "text.below.photo")

--- a/TextifyApp/TextifyUI/Features/Textify/TextifyView.swift
+++ b/TextifyApp/TextifyUI/Features/Textify/TextifyView.swift
@@ -549,7 +549,10 @@ public struct TextifyView: View {
                         Slider(
                             value: viewModel.outputWidthBinding,
                             in: 30...150,
-                            step: 10
+                            step: 10,
+                            onEditingChanged: { isEditing in
+                                viewModel.handleOutputWidthEditingChanged(isEditing)
+                            }
                         )
 
                         Text("값이 커질수록 디테일은 늘고 문자열 길이도 길어집니다.")

--- a/TextifyApp/TextifyUI/Features/Textify/TextifyViewModel.swift
+++ b/TextifyApp/TextifyUI/Features/Textify/TextifyViewModel.swift
@@ -166,10 +166,7 @@ public final class TextifyViewModel {
         Binding(
             get: { Double(self.outputWidth) },
             set: { newValue in
-                self.outputWidth = Int(newValue)
-                Task {
-                    await self.throttledGenerate()
-                }
+                self.handleOutputWidthValueChange(newValue)
             }
         )
     }
@@ -219,6 +216,14 @@ public final class TextifyViewModel {
         taskManager.cancel()
     }
 
+    func handleOutputWidthEditingChanged(_ isEditing: Bool) {
+        guard !isEditing else { return }
+
+        Task {
+            await self.commitOutputWidthChange()
+        }
+    }
+
     public func dismissError() {
         errorMessage = nil
         errorAction = nil
@@ -233,11 +238,7 @@ public final class TextifyViewModel {
     }
 
     public func generate() async {
-        generationRequestID += 1
-        let requestID = generationRequestID
-
-        isGenerating = true
-        dismissError()
+        let requestID = beginGenerationRequest(isFinal: true)
 
         let characters = resolvedCharacters
         let width = outputWidth
@@ -312,7 +313,7 @@ public final class TextifyViewModel {
     }
 
     public func saveAsImage() async {
-        guard let textArt else { return }
+        guard let textArt, !isSavingImage else { return }
 
         isSavingImage = true
         dismissError()
@@ -324,8 +325,11 @@ public final class TextifyViewModel {
             hapticsService.notification(type: .success)
             resetSavedFeedback()
         } catch {
-            let presentation = saveErrorPresentation(for: error)
-            presentError(presentation.message, action: presentation.action)
+            let presentation = makeImageExportPresentation(for: error, context: .save)
+            presentError(
+                presentation.message,
+                action: presentation.suggestsOpeningSettings ? .openSettings : nil
+            )
             hapticsService.notification(type: .error)
             logger.error("Save image failed: \(String(describing: error), privacy: .public)")
         }
@@ -349,6 +353,34 @@ public final class TextifyViewModel {
         selectedPreset.resolvedCharacters(customInput: customCharacters)
     }
 
+    private func handleOutputWidthValueChange(_ newValue: Double) {
+        outputWidth = Int(newValue)
+
+        Task {
+            await finalDebouncer.cancel()
+            await self.throttledGenerate()
+        }
+    }
+
+    private func commitOutputWidthChange() async {
+        await finalDebouncer.cancel()
+        await widthThrottler.reset()
+        await generate()
+    }
+
+    private func beginGenerationRequest(isFinal: Bool) -> Int {
+        generationRequestID += 1
+
+        if isFinal {
+            isGenerating = true
+            dismissError()
+        } else {
+            isGenerating = false
+        }
+
+        return generationRequestID
+    }
+
     private func throttledGenerate() async {
         await widthThrottler.throttle { [weak self] in
             await self?.generatePreview()
@@ -356,6 +388,7 @@ public final class TextifyViewModel {
     }
 
     private func generatePreview() async {
+        let requestID = beginGenerationRequest(isFinal: false)
         let characters = resolvedCharacters
         let width = outputWidth
         let invert = invertBrightness
@@ -381,6 +414,7 @@ public final class TextifyViewModel {
                 try Task.checkCancellation()
 
                 await MainActor.run {
+                    guard requestID == self.generationRequestID else { return }
                     self.textArt = result
                     self.dismissError()
                 }
@@ -446,20 +480,4 @@ public final class TextifyViewModel {
         errorAction = action
     }
 
-    private func saveErrorPresentation(for error: Error) -> (message: String, action: TextifyErrorAction?) {
-        guard let exportError = error as? ImageExportError else {
-            return ("이미지 저장에 실패했습니다.", nil)
-        }
-
-        switch exportError {
-        case .permissionDenied:
-            return ("사진 보관함 접근이 거부되어 저장할 수 없습니다. 설정에서 사진 접근을 허용해 주세요.", .openSettings)
-        case .permissionRestricted:
-            return ("이 기기에서는 사진 보관함 저장이 제한되어 있습니다.", nil)
-        case .renderingFailed:
-            return ("저장용 이미지를 만드는 데 실패했습니다.", nil)
-        case .saveFailed, .platformNotSupported:
-            return ("이미지 저장에 실패했습니다.", nil)
-        }
-    }
 }

--- a/TextifyApp/TextifyUI/Models/AppError.swift
+++ b/TextifyApp/TextifyUI/Models/AppError.swift
@@ -73,3 +73,73 @@ public enum AppError: LocalizedError, Sendable {
         }
     }
 }
+
+enum ImageExportPresentationContext {
+    case save
+    case sharePreparation
+}
+
+struct ImageExportPresentation {
+    let message: String
+    let suggestsOpeningSettings: Bool
+}
+
+func makeImageExportPresentation(
+    for error: Error,
+    context: ImageExportPresentationContext
+) -> ImageExportPresentation {
+    guard let exportError = error as? ImageExportError else {
+        switch context {
+        case .save:
+            return ImageExportPresentation(
+                message: "이미지 저장에 실패했습니다.",
+                suggestsOpeningSettings: false
+            )
+        case .sharePreparation:
+            return ImageExportPresentation(
+                message: "공유용 이미지를 준비하지 못했습니다.",
+                suggestsOpeningSettings: false
+            )
+        }
+    }
+
+    switch context {
+    case .save:
+        switch exportError {
+        case .permissionDenied:
+            return ImageExportPresentation(
+                message: "사진 보관함 접근이 거부되어 저장할 수 없습니다. 설정에서 사진 접근을 허용해 주세요.",
+                suggestsOpeningSettings: true
+            )
+        case .permissionRestricted:
+            return ImageExportPresentation(
+                message: "이 기기에서는 사진 보관함 저장이 제한되어 있습니다.",
+                suggestsOpeningSettings: false
+            )
+        case .renderingFailed:
+            return ImageExportPresentation(
+                message: "저장용 이미지를 만드는 데 실패했습니다.",
+                suggestsOpeningSettings: false
+            )
+        case .saveFailed, .platformNotSupported:
+            return ImageExportPresentation(
+                message: "이미지 저장에 실패했습니다.",
+                suggestsOpeningSettings: false
+            )
+        }
+
+    case .sharePreparation:
+        switch exportError {
+        case .renderingFailed:
+            return ImageExportPresentation(
+                message: "공유용 이미지를 만드는 데 실패했습니다.",
+                suggestsOpeningSettings: false
+            )
+        case .saveFailed, .platformNotSupported, .permissionDenied, .permissionRestricted:
+            return ImageExportPresentation(
+                message: "공유용 이미지를 준비하지 못했습니다.",
+                suggestsOpeningSettings: false
+            )
+        }
+    }
+}

--- a/TextifyApp/TextifyUI/Services/PhotoLibraryService.swift
+++ b/TextifyApp/TextifyUI/Services/PhotoLibraryService.swift
@@ -2,6 +2,9 @@ import Foundation
 import CoreGraphics
 import PhotosUI
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// Errors that can occur during photo library operations
 public enum PhotoLibraryError: Error, LocalizedError {
@@ -26,16 +29,17 @@ public final class PhotoLibraryService: Sendable {
 
     public init() {}
 
-    /// Loads a CGImage from a PhotosPickerItem
+    /// Loads a CGImage from a PhotosPickerItem with EXIF orientation applied.
     /// - Parameter item: The selected photo picker item
-    /// - Returns: A CGImage representation of the photo
+    /// - Returns: An orientation-normalized CGImage representation of the photo
     public func loadImage(from item: PhotosPickerItem) async throws -> CGImage {
-        // Load transferable data
         guard let data = try await item.loadTransferable(type: Data.self) else {
             throw PhotoLibraryError.loadFailed
         }
 
-        // Create CGImage from data
+        #if canImport(UIKit)
+        return try createOrientationNormalizedCGImage(from: data)
+        #else
         guard let dataProvider = CGDataProvider(data: data as CFData),
               let cgImage = CGImage(
                 jpegDataProviderSource: dataProvider,
@@ -48,18 +52,44 @@ public final class PhotoLibraryService: Sendable {
                 shouldInterpolate: true,
                 intent: .defaultIntent
               ) else {
-            // Try using UIImage as fallback
-            #if canImport(UIKit)
-            guard let uiImage = UIImage(data: data),
-                  let cgImage = uiImage.cgImage else {
+            throw PhotoLibraryError.cgImageCreationFailed
+        }
+        return cgImage
+        #endif
+    }
+
+    #if canImport(UIKit)
+    /// Creates a CGImage from data with EXIF orientation baked into the pixels.
+    ///
+    /// `UIImage(data:)` reads EXIF orientation but `uiImage.cgImage` returns
+    /// raw un-rotated pixels. This method draws the UIImage into a new bitmap
+    /// context so the orientation transform is applied to the actual pixel data.
+    func createOrientationNormalizedCGImage(from data: Data) throws -> CGImage {
+        guard let uiImage = UIImage(data: data) else {
+            throw PhotoLibraryError.cgImageCreationFailed
+        }
+
+        // Fast path: orientation is already correct
+        if uiImage.imageOrientation == .up {
+            guard let cgImage = uiImage.cgImage else {
                 throw PhotoLibraryError.cgImageCreationFailed
             }
             return cgImage
-            #else
-            throw PhotoLibraryError.cgImageCreationFailed
-            #endif
         }
 
+        // Redraw to bake in the orientation transform.
+        // Force scale 1.0 so the resulting CGImage has 1:1 pixel dimensions.
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1.0
+        let renderer = UIGraphicsImageRenderer(size: uiImage.size, format: format)
+        let normalized = renderer.image { _ in
+            uiImage.draw(at: .zero)
+        }
+
+        guard let cgImage = normalized.cgImage else {
+            throw PhotoLibraryError.cgImageCreationFailed
+        }
         return cgImage
     }
+    #endif
 }

--- a/TextifyApp/TextifyUITests/HistoryDetailViewModelTests.swift
+++ b/TextifyApp/TextifyUITests/HistoryDetailViewModelTests.swift
@@ -20,8 +20,31 @@ actor HistoryDetailExportServiceMock: ImageExportServiceProtocol {
 }
 
 actor FailingHistoryDetailExportServiceMock: ImageExportServiceProtocol {
+    private let error: Error
+
+    init(error: Error = ImageExportError.saveFailed) {
+        self.error = error
+    }
+
     func exportAsImage(textArt: TextArt) async throws -> URL {
-        throw ImageExportError.saveFailed
+        throw error
+    }
+
+    func saveToPhotos(textArt: TextArt) async throws {}
+}
+
+actor SlowHistoryDetailExportServiceMock: ImageExportServiceProtocol {
+    private(set) var exportCallCount = 0
+    private let delay: Duration
+
+    init(delay: Duration = .milliseconds(150)) {
+        self.delay = delay
+    }
+
+    func exportAsImage(textArt: TextArt) async throws -> URL {
+        exportCallCount += 1
+        try await Task.sleep(for: delay)
+        return FileManager.default.temporaryDirectory.appendingPathComponent("history-detail-share.png")
     }
 
     func saveToPhotos(textArt: TextArt) async throws {}
@@ -96,7 +119,54 @@ struct HistoryDetailViewModelTests {
         await viewModel.prepareShareImage()
 
         #expect(viewModel.shareURL == nil)
-        #expect(viewModel.errorMessage == "이미지 공유 준비에 실패했습니다.")
+        #expect(viewModel.errorMessage == "공유용 이미지를 준비하지 못했습니다.")
+        #expect(viewModel.isPreparingShare == false)
+    }
+
+    @Test("Share preparation rendering failure uses the shared export presentation")
+    @MainActor
+    func testPrepareShareImageRenderingFailure() async throws {
+        let clipboard = MockClipboardService()
+        let export = FailingHistoryDetailExportServiceMock(error: ImageExportError.renderingFailed)
+        let viewModel = HistoryDetailViewModel(
+            entry: Self.makeEntry(),
+            clipboardService: clipboard,
+            exportService: export
+        )
+
+        await viewModel.prepareShareImage()
+
+        #expect(viewModel.shareURL == nil)
+        #expect(viewModel.errorMessage == "공유용 이미지를 만드는 데 실패했습니다.")
+        #expect(viewModel.isPreparingShare == false)
+    }
+
+    @Test("Share preparation ignores re-entrant requests while export is in flight")
+    @MainActor
+    func testPrepareShareImagePreventsReentry() async throws {
+        let clipboard = MockClipboardService()
+        let export = SlowHistoryDetailExportServiceMock()
+        let viewModel = HistoryDetailViewModel(
+            entry: Self.makeEntry(),
+            clipboardService: clipboard,
+            exportService: export
+        )
+
+        let firstTask = Task {
+            await viewModel.prepareShareImage()
+        }
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        let secondTask = Task {
+            await viewModel.prepareShareImage()
+        }
+
+        await firstTask.value
+        await secondTask.value
+
+        #expect(await export.exportCallCount == 1)
+        #expect(viewModel.shareURL?.lastPathComponent == "history-detail-share.png")
         #expect(viewModel.isPreparingShare == false)
     }
 }

--- a/TextifyApp/TextifyUITests/PhotoLibraryServiceTests.swift
+++ b/TextifyApp/TextifyUITests/PhotoLibraryServiceTests.swift
@@ -1,0 +1,124 @@
+import Testing
+import Foundation
+import CoreGraphics
+import UIKit
+import ImageIO
+@testable import TextifyUI
+
+@Suite("PhotoLibraryService Orientation Tests")
+struct PhotoLibraryServiceTests {
+
+    private let service = PhotoLibraryService()
+
+    /// Creates JPEG data with an explicit EXIF orientation tag using ImageIO.
+    /// The raw pixel buffer has the given width×height; the EXIF tag tells
+    /// decoders how to rotate the pixels for correct display.
+    private static func createJPEGData(
+        pixelWidth: Int,
+        pixelHeight: Int,
+        exifOrientation: UInt32
+    ) -> Data? {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: pixelWidth,
+            height: pixelHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        context.setFillColor(UIColor.red.cgColor)
+        context.fill(CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
+
+        guard let cgImage = context.makeImage() else { return nil }
+
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            "public.jpeg" as CFString,
+            1,
+            nil
+        ) else { return nil }
+
+        let properties: [CFString: Any] = [
+            kCGImagePropertyOrientation: exifOrientation
+        ]
+        CGImageDestinationAddImage(destination, cgImage, properties as CFDictionary)
+
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
+    }
+
+    // MARK: - Orientation .up (EXIF 1)
+
+    @Test("Orientation .up — dimensions unchanged, fast path")
+    func testOrientationUp() throws {
+        // EXIF orientation 1 = .up (no rotation)
+        let data = try #require(Self.createJPEGData(pixelWidth: 20, pixelHeight: 10, exifOrientation: 1))
+        let result = try service.createOrientationNormalizedCGImage(from: data)
+        #expect(result.width == 20)
+        #expect(result.height == 10)
+    }
+
+    // MARK: - Orientation .right (EXIF 6, iPhone portrait)
+
+    @Test("Orientation .right (iPhone portrait) — width and height swapped")
+    func testOrientationRight() throws {
+        // EXIF orientation 6 = .right (90° CW)
+        // Raw pixels: 20×10 → Display: 10×20
+        let data = try #require(Self.createJPEGData(pixelWidth: 20, pixelHeight: 10, exifOrientation: 6))
+        let result = try service.createOrientationNormalizedCGImage(from: data)
+        #expect(result.width == 10)
+        #expect(result.height == 20)
+    }
+
+    // MARK: - Orientation .left (EXIF 8)
+
+    @Test("Orientation .left — width and height swapped")
+    func testOrientationLeft() throws {
+        // EXIF orientation 8 = .left (90° CCW)
+        // Raw pixels: 20×10 → Display: 10×20
+        let data = try #require(Self.createJPEGData(pixelWidth: 20, pixelHeight: 10, exifOrientation: 8))
+        let result = try service.createOrientationNormalizedCGImage(from: data)
+        #expect(result.width == 10)
+        #expect(result.height == 20)
+    }
+
+    // MARK: - Invalid data
+
+    @Test("Invalid data throws cgImageCreationFailed")
+    func testInvalidData() throws {
+        let invalidData = Data([0x00, 0x01, 0x02, 0x03])
+        #expect(throws: PhotoLibraryError.cgImageCreationFailed) {
+            try service.createOrientationNormalizedCGImage(from: invalidData)
+        }
+    }
+
+    // MARK: - PNG (no EXIF orientation)
+
+    @Test("PNG data without EXIF orientation — normal operation")
+    func testPNGData() throws {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = try #require(CGContext(
+            data: nil,
+            width: 15,
+            height: 25,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(UIColor.blue.cgColor)
+        context.fill(CGRect(x: 0, y: 0, width: 15, height: 25))
+
+        let cgImage = try #require(context.makeImage())
+        let uiImage = UIImage(cgImage: cgImage)
+        let pngData = try #require(uiImage.pngData())
+
+        let result = try service.createOrientationNormalizedCGImage(from: pngData)
+        #expect(result.width == 15)
+        #expect(result.height == 25)
+    }
+}

--- a/TextifyApp/TextifyUITests/TextifyViewModelTests.swift
+++ b/TextifyApp/TextifyUITests/TextifyViewModelTests.swift
@@ -67,6 +67,47 @@ actor CapturingTextArtGenerator: TextArtGenerating {
     }
 }
 
+actor OptionAwareTextArtGenerator: TextArtGenerating {
+    private(set) var generateCallCount = 0
+    private(set) var receivedWidths: [Int] = []
+    private(set) var receivedContrasts: [Float] = []
+    private let slowWidths: Set<Int>
+    private let slowDelay: Duration
+    private let fastDelay: Duration
+
+    init(
+        slowWidths: Set<Int> = [],
+        slowDelay: Duration = .milliseconds(200),
+        fastDelay: Duration = .milliseconds(10)
+    ) {
+        self.slowWidths = slowWidths
+        self.slowDelay = slowDelay
+        self.fastDelay = fastDelay
+    }
+
+    func generate(
+        from image: CGImage,
+        palette: CharacterPalette,
+        options: ProcessingOptions
+    ) async throws -> TextArt {
+        generateCallCount += 1
+        receivedWidths.append(options.outputWidth)
+        receivedContrasts.append(options.contrastBoost)
+
+        let delay = slowWidths.contains(options.outputWidth) ? slowDelay : fastDelay
+        try await Task.sleep(for: delay)
+
+        let row = "\(options.outputWidth)-\(String(format: "%.1f", options.contrastBoost))"
+        return TextArt(
+            rows: [row],
+            width: options.outputWidth,
+            height: 1,
+            sourceCharacters: String(palette.characters),
+            createdAt: Date()
+        )
+    }
+}
+
 actor ErrorThrowingGenerator: TextArtGenerating {
     func generate(
         from image: CGImage,
@@ -112,6 +153,24 @@ actor FailingImageExportService: ImageExportServiceProtocol {
 
     func saveToPhotos(textArt: TextArt) async throws {
         throw error
+    }
+}
+
+actor SlowImageExportService: ImageExportServiceProtocol {
+    private(set) var saveCallCount = 0
+    private let delay: Duration
+
+    init(delay: Duration = .milliseconds(150)) {
+        self.delay = delay
+    }
+
+    func exportAsImage(textArt: TextArt) async throws -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("slow-export.png")
+    }
+
+    func saveToPhotos(textArt: TextArt) async throws {
+        saveCallCount += 1
+        try await Task.sleep(for: delay)
     }
 }
 
@@ -192,8 +251,8 @@ extension TextifyViewModelTests {
     static func makeViewModel(
         generator: any TextArtGenerating,
         clipboard: MockClipboardService = MockClipboardService(),
-        export: MockImageExportService = MockImageExportService(),
-        historyRecorder: MockHistoryRecorder = MockHistoryRecorder(),
+        export: any ImageExportServiceProtocol = MockImageExportService(),
+        historyRecorder: any TextArtHistoryRecording = MockHistoryRecorder(),
         haptics: MockHapticsService = MockHapticsService(),
         feedbackResetDelay: Duration = .milliseconds(100)
     ) -> TextifyViewModel {
@@ -339,6 +398,128 @@ struct TextifyViewModelTests {
         try await Task.sleep(for: .milliseconds(20))
 
         #expect(await historyRecorder.recordedRequests.count == 1)
+    }
+
+    @Test("Output width interaction commits the final width after rapid changes")
+    @MainActor
+    func testOutputWidthInteractionCommitsFinalWidth() async throws {
+        let generator = OptionAwareTextArtGenerator()
+        let viewModel = Self.makeViewModel(generator: generator)
+
+        viewModel.outputWidthBinding.wrappedValue = 40
+        try await Task.sleep(for: .milliseconds(10))
+        viewModel.outputWidthBinding.wrappedValue = 80
+        try await Task.sleep(for: .milliseconds(10))
+        viewModel.outputWidthBinding.wrappedValue = 120
+        viewModel.handleOutputWidthEditingChanged(false)
+
+        try await Task.sleep(for: .milliseconds(350))
+
+        #expect(viewModel.outputWidth == 120)
+        #expect(viewModel.textArt?.width == 120)
+        #expect(viewModel.textArt?.asString == "120-1.0")
+        #expect(await generator.receivedWidths.last == 120)
+        #expect(await generator.generateCallCount >= 2)
+    }
+
+    @Test("Stale width preview does not override the latest committed result")
+    @MainActor
+    func testStalePreviewDoesNotOverrideCommittedGeneration() async throws {
+        let generator = OptionAwareTextArtGenerator(slowWidths: [30])
+        let viewModel = Self.makeViewModel(generator: generator)
+
+        viewModel.outputWidthBinding.wrappedValue = 30
+        try await Task.sleep(for: .milliseconds(20))
+        viewModel.outputWidthBinding.wrappedValue = 150
+        viewModel.handleOutputWidthEditingChanged(false)
+
+        try await Task.sleep(for: .milliseconds(450))
+
+        #expect(viewModel.outputWidth == 150)
+        #expect(viewModel.textArt?.width == 150)
+        #expect(viewModel.textArt?.asString == "150-1.0")
+        #expect(await generator.receivedWidths.contains(30))
+        #expect(await generator.receivedWidths.last == 150)
+    }
+
+    @Test("Save action ignores re-entrant requests while a save is in flight")
+    @MainActor
+    func testSaveActionPreventsReentrantSaves() async throws {
+        let generator = MockTextArtGenerator()
+        let export = SlowImageExportService()
+        let viewModel = Self.makeViewModel(generator: generator, export: export)
+        viewModel.textArt = TextArt(
+            rows: ["@@", "##"],
+            width: 2,
+            height: 2,
+            sourceCharacters: "@#",
+            createdAt: Date()
+        )
+
+        let firstSave = Task {
+            await viewModel.saveAsImage()
+        }
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        let secondSave = Task {
+            await viewModel.saveAsImage()
+        }
+
+        await firstSave.value
+        await secondSave.value
+
+        #expect(await export.saveCallCount == 1)
+        #expect(viewModel.isSavingImage == false)
+    }
+
+    @Test("Copy then save records history only once for the same result")
+    @MainActor
+    func testCopyThenSavePersistsHistoryOnce() async throws {
+        let generator = MockTextArtGenerator()
+        let historyRecorder = MockHistoryRecorder()
+        let clipboard = MockClipboardService()
+        let export = MockImageExportService()
+        let viewModel = Self.makeViewModel(
+            generator: generator,
+            clipboard: clipboard,
+            export: export,
+            historyRecorder: historyRecorder
+        )
+
+        await viewModel.generate()
+        viewModel.copyToClipboard()
+        try await Task.sleep(for: .milliseconds(20))
+        await viewModel.saveAsImage()
+
+        #expect(await historyRecorder.recordedRequests.count == 1)
+    }
+
+    @Test("History is recorded again when the displayed option set changes")
+    @MainActor
+    func testHistoryPersistsAgainWhenOptionsChange() async throws {
+        let generator = OptionAwareTextArtGenerator()
+        let historyRecorder = MockHistoryRecorder()
+        let clipboard = MockClipboardService()
+        let viewModel = Self.makeViewModel(
+            generator: generator,
+            clipboard: clipboard,
+            historyRecorder: historyRecorder
+        )
+
+        await viewModel.generate()
+        viewModel.copyToClipboard()
+        try await Task.sleep(for: .milliseconds(20))
+
+        viewModel.contrastBoost = 1.5
+        await viewModel.generate()
+        viewModel.copyToClipboard()
+        try await Task.sleep(for: .milliseconds(20))
+
+        let recordedRequests = await historyRecorder.recordedRequests
+        #expect(recordedRequests.count == 2)
+        #expect(abs(recordedRequests[0].contrastBoost - 1.0) < 0.0001)
+        #expect(abs(recordedRequests[1].contrastBoost - 1.5) < 0.0001)
     }
 
     @Test("Custom palette and contrast are forwarded to generator options")


### PR DESCRIPTION
## Summary
- 이미지 저장/공유 시 중복 요청 방지를 위한 re-entrancy guard 추가
- `makeImageExportPresentation` 헬퍼로 이미지 내보내기 에러 메시지를 컨텍스트별(저장/공유)로 통합
- 슬라이더 드래그 종료 시 최종 값으로 생성하도록 output width 인터랙션 리팩토링 (stale preview 방지)
- `beginGenerationRequest`로 생성 요청 ID 관리 일원화
- re-entrancy, stale preview, history 기록 엣지 케이스에 대한 테스트 추가
- Xcode 프로젝트 DEVELOPMENT_TEAM 설정 및 파일 타입 수정으로 빌드 안정성 개선

## Test plan
- [x] `HistoryDetailViewModelTests` — 공유 준비 에러 메시지 및 re-entrancy 방지 검증
- [x] `TextifyViewModelTests` — 출력 폭 커밋, stale preview 무시, 저장 re-entrancy, 히스토리 중복 방지 검증
- [ ] 수동 QA: 슬라이더 빠르게 드래그 후 릴리즈 시 최종 값 반영 확인
- [ ] 수동 QA: 저장/공유 버튼 연타 시 중복 동작 없음 확인

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)